### PR TITLE
refactor: split graphql proxy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,12 @@ app.use(proxy('/scrape', {
   },
 }));
 
+app.use(proxy('/graphql', {
+  target: config.apiUrl,
+  changeOrigin: true,
+  xfwd: true,
+}));
+
 app.use(proxy('/', {
   target: config.apiUrl,
   changeOrigin: true,


### PR DESCRIPTION
Split GraphQL proxy to remove the service authentication from it.
It is the second step towards decoupling the gateway and the api