### PR TITLE
feat: update reputation upon pubsub event

### DIFF
--- a/migrations/20200916175402_reputation.js
+++ b/migrations/20200916175402_reputation.js
@@ -1,0 +1,9 @@
+exports.up = knex =>
+  knex.schema.table('users', (table) => {
+    table.integer('reputation').default(0);
+  });
+
+exports.down = knex =>
+  knex.schema.table('users', (table) => {
+    table.dropColumns(['reputation']);
+  });

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -53,9 +53,15 @@ const update = (id, user) =>
     .where('id', '=', id)
     .update(toSnakeCase(Object.assign({}, _.pick(user, ['name', 'email', 'image', 'company', 'title', 'infoConfirmed', 'premium', 'acceptedMarketing']), { updatedAt: new Date() })));
 
+const updateReputation = (id, reputation) =>
+  db(table)
+    .where('id', '=', id)
+    .update({ reputation });
+
 export default {
   getById,
   checkDuplicateEmail,
   add,
   update,
+  updateReputation,
 };

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -4,6 +4,7 @@ import config from './config';
 export const pubsub = new PubSub();
 export const userRegisteredTopic = pubsub.topic('user-registered');
 export const userUpdatedTopic = pubsub.topic('user-updated');
+export const userReputationUpdatedTopic = pubsub.topic('user-reputation-updated');
 
 export const messageToJson = message =>
   JSON.parse(message.data.toString('utf8'));

--- a/src/workers/index.js
+++ b/src/workers/index.js
@@ -1,6 +1,7 @@
 import { pubsub } from '../pubsub';
 import slackNotification from './slackNotification';
 import updateMailingList from './updateMailingList';
+import updateReputation from './updateReputation';
 
 const initializeWorker = async (worker, log) => {
   const topic = pubsub.topic(worker.topic);
@@ -16,4 +17,5 @@ const initializeWorker = async (worker, log) => {
 export const startWorkers = async (log) => {
   await initializeWorker(slackNotification, log);
   await initializeWorker(updateMailingList, log);
+  await initializeWorker(updateReputation, log);
 };

--- a/src/workers/updateReputation.js
+++ b/src/workers/updateReputation.js
@@ -1,0 +1,19 @@
+import { envBasedName, messageToJson, userReputationUpdatedTopic } from '../pubsub';
+import user from '../models/user';
+
+const worker = {
+  topic: userReputationUpdatedTopic.name,
+  subscription: envBasedName('update-reputation'),
+  handler: async (message, log) => {
+    const data = messageToJson(message);
+    try {
+      await user.updateReputation(data.userId, data.reputation);
+      message.ack();
+    } catch (err) {
+      log.error({ messageId: message.id, err, data }, 'failed to update reputation');
+      message.nack();
+    }
+  },
+};
+
+export default worker;

--- a/test/integration/models/user.js
+++ b/test/integration/models/user.js
@@ -52,4 +52,15 @@ describe('user model', () => {
       acceptedMarketing: true,
     }));
   });
+
+  it('should update user reputation', async () => {
+    await user.add(fixture[2].id);
+    await user.updateReputation(fixture[2].id, 2);
+    const model = await db
+      .select('reputation')
+      .from('users')
+      .where('id', '=', fixture[2].id)
+      .limit(1);
+    expect(model[0].reputation).to.deep.equal(2);
+  });
 });


### PR DESCRIPTION
Denormalize the reputation information so the gateway can return it as part of the profile.
Upon Pub/Sub message this service updates its local reputation info